### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -69,6 +69,7 @@ export const POST = async (req: Request) => {
 
     return new NextResponse(JSON.stringify({ success: true }));
   } catch (error) {
-    return new NextResponse(JSON.stringify(error), { status: 500 });
+    console.error("An error occurred:", error); // Log the error details on the server
+    return new NextResponse(JSON.stringify({ message: "An unexpected error occurred" }), { status: 500 });
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/icco/photos/security/code-scanning/2](https://github.com/icco/photos/security/code-scanning/2)

To fix the issue, we should avoid exposing the raw `error` object to the user. Instead, we can log the full error details on the server for debugging purposes and return a generic error message to the client. This ensures that sensitive information, such as stack traces, is not exposed to end users.

The fix involves:
1. Logging the error details (e.g., stack trace) to the server console or a logging system.
2. Returning a generic error message to the client, such as "An unexpected error occurred."

Changes will be made to the `catch` block starting at line 71 to implement this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
