### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/src/app/api/list/route.ts
+++ b/src/app/api/list/route.ts
@@ -26,6 +26,7 @@ export const GET = async () => {
 
     return new NextResponse(JSON.stringify({ photos }));
   } catch (error) {
-    return new NextResponse(JSON.stringify(error), { status: 500 });
+    console.error("An error occurred:", error); // Log the full error details on the server
+    return new NextResponse(JSON.stringify({ message: "An unexpected error occurred" }), { status: 500 });
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/icco/photos/security/code-scanning/1](https://github.com/icco/photos/security/code-scanning/1)

To fix the issue, we need to ensure that sensitive information in the `error` object is not exposed to the client. Instead of sending the raw `error` object, we should:
1. Log the full error details (including the stack trace) on the server for debugging purposes.
2. Send a generic error message to the client, such as "An unexpected error occurred," to avoid revealing sensitive information.

This can be achieved by replacing the `JSON.stringify(error)` response with a generic error message and logging the full error details using `console.error` or a logging library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
