### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN \
 
 # Production image, copy all the files and run next
 FROM base AS runner
+
+LABEL org.opencontainers.image.source=https://github.com/icco/photos
+LABEL org.opencontainers.image.description="ghcr.io/icco/photos container image"
+LABEL org.opencontainers.image.licenses=MIT
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN \
 FROM base AS runner
 
 LABEL org.opencontainers.image.source=https://github.com/icco/photos
-LABEL org.opencontainers.image.description="ghcr.io/icco/photos container image"
+LABEL org.opencontainers.image.description="Photo uploader and gallery for photos.natwelch.com; a Next.js app for uploading and viewing personal photos."
 LABEL org.opencontainers.image.licenses=MIT
 WORKDIR /app
 


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)