### PR TITLE
feat(header): add About icon and bump react-common to 2026.510.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@date-fns/tz": "^1.0.2",
     "@google-cloud/storage": "^7.13.0",
     "@heroicons/react": "^2.1.5",
-    "@icco/react-common": "^2026.430.1",
+    "@icco/react-common": "^2026.510.2",
     "date-fns": "^4.1.0",
     "jsdom": "^29.0.0",
     "next": "^16.2.4",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,17 @@
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { SiteHeader } from "@icco/react-common/SiteHeader";
 
 export default function Header() {
   return (
-    <SiteHeader links={[{ name: "About", href: "/about", prefetch: false }]} />
+    <SiteHeader
+      links={[
+        {
+          name: "About",
+          href: "/about",
+          prefetch: false,
+          icon: <InformationCircleIcon className="h-5 w-5" />,
+        },
+      ]}
+    />
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,10 +400,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@icco/react-common@^2026.430.1":
-  version "2026.430.1"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.430.1/36885424816801ca56fce83bb5b621f08ad9c352#36885424816801ca56fce83bb5b621f08ad9c352"
-  integrity sha512-69x0XpmkQcGkZzVkjx1a5xJcUst98o1sttfdeeudoYJ1FLHI+Fytb9U2IcGvOZ7t3EpmkMYOC9FHFHEpBX4WYA==
+"@icco/react-common@^2026.510.2":
+  version "2026.510.2"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.510.2/148b54b2cb740bc174ba2550796c8cfa82d64a0d#148b54b2cb740bc174ba2550796c8cfa82d64a0d"
+  integrity sha512-U5rihytjY3+lGKV3kbrVlT+buSQNc6gxSQIQ+McR7icb5hiXJmfwNeaSor7wEkv4SdKe2vGLcYlWoBwLvCYAHw==
   dependencies:
     "@wrksz/themes" "^0.9.0"
     vivus "^0.4.6"


### PR DESCRIPTION
## Summary

- Bumps `@icco/react-common` to `^2026.510.2` (icco/react-common#106), which adds icon support to `SiteHeader` nav links and collapses labels to icon-only below the `md` breakpoint.
- Adds an `InformationCircleIcon` to the About link via the new `icon` prop.

