### PR TITLE
fix: run @google-cloud/storage unbundled to fix GCS auth on node 26

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,9 @@ const domain = process.env.DOMAIN || `http://${hostname}:${port}`;
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  // Bundled (turbopack) node-fetch inside the GCS auth stack breaks on node
+  // 26 (ERR_STREAM_PREMATURE_CLOSE on every token fetch); run it unbundled.
+  serverExternalPackages: ["@google-cloud/storage"],
   poweredByHeader: false,
   trailingSlash: false,
   productionBrowserSourceMaps: true,


### PR DESCRIPTION
photos.natwelch.com has served 500s from `/api/list` (and uploads have been broken) since the June 23 image build. Every GCS call fails during the oauth token fetch with `ERR_STREAM_PREMATURE_CLOSE`.

**Root cause:** the turbopack-bundled copy of node-fetch/gaxios (pulled in by `@google-cloud/storage`) breaks on the node 26 runtime from #472. Verified by experiment:

- stock node-fetch 2.7.0 on node 26: works
- current image's bundle on node 22: works (full photo list returned)
- current image's bundle on node 26: fails deterministically, even from a cold container

**Fix:** `serverExternalPackages: ["@google-cloud/storage"]` so the GCS stack runs unbundled from node_modules, keeping the node 26 runtime.